### PR TITLE
Make metanetkan's version overrides more specific

### DIFF
--- a/HotSpot.netkan
+++ b/HotSpot.netkan
@@ -15,28 +15,28 @@
     "x_netkan_version_edit": "^v(?<version>\\d+\\.\\d+\\.\\d+)$",
     "x_netkan_override": [
         {
-            "version": ">=0.1.0",
+            "version": [ ">=0.1.0", "<0.2.0" ],
             "override": {
                 "ksp_version_min": "1.0.2",
                 "ksp_version_max": "1.0.2"
             }
         },
         {
-            "version": ">=0.2.0",
+            "version": [ ">=0.2.0", "<0.3.0" ],
             "override": {
                 "ksp_version_min": "1.0.3",
                 "ksp_version_max": "1.0.3"
             }
         },
         {
-            "version": ">=0.3.0",
+            "version": [ ">=0.3.0", "<0.4.4" ],
             "override": {
                 "ksp_version_min": "1.0.4",
                 "ksp_version_max": "1.0.4"
             }
         },
         {
-            "version": ">=0.4.4",
+            "version": [ ">=0.4.4", "<0.5.0" ],
             "override": {
                 "ksp_version_min": "1.0.4",
                 "ksp_version_max": "1.0.5",
@@ -46,7 +46,7 @@
             }
         },
         {
-            "version": ">=0.5.0",
+            "version": [ ">=0.5.0", "<0.5.1" ],
             "override": {
                 "ksp_version_min": "1.0.5",
                 "ksp_version_max": "1.0.5",
@@ -57,7 +57,7 @@
             }
         },
         {
-            "version": ">=0.5.1",
+            "version": [ ">=0.5.1", "<0.6.0" ],
             "override": {
                 "ksp_version_min": "1.1.0",
                 "ksp_version_max": "1.1.2",
@@ -68,7 +68,7 @@
             }
         },
         {
-            "version": ">=0.6.0",
+            "version": [ ">=0.6.0", "<0.7.0" ],
             "override": {
                 "ksp_version_min": "1.1.2",
                 "ksp_version_max": "1.1.2",
@@ -79,7 +79,7 @@
             }
         },
         {
-            "version": ">=0.7.0",
+            "version": [ ">=0.7.0", "<0.7.1" ],
             "override": {
                 "ksp_version_min": "1.1.2",
                 "ksp_version_max": "1.1.3",
@@ -90,7 +90,7 @@
             }
         },
         {
-            "version": ">=0.7.1",
+            "version": [ ">=0.7.1", "<0.7.2" ],
             "override": {
                 "ksp_version_min": "1.2.0",
                 "ksp_version_max": "1.2.0",
@@ -101,7 +101,7 @@
             }
         },
         {
-            "version": ">=0.7.2",
+            "version": [ ">=0.7.2", "<0.7.3" ],
             "override": {
                 "ksp_version_min": "1.2.0",
                 "ksp_version_max": "1.2.2",
@@ -112,7 +112,7 @@
             }
         },
         {
-            "version": ">=0.7.3",
+            "version": [ ">=0.7.3", "<0.8.0" ],
             "override": {
                 "ksp_version_min": "1.3.0",
                 "ksp_version_max": "1.3.0",
@@ -123,7 +123,7 @@
             }
         },
         {
-            "version": ">=0.8.0",
+            "version": [ ">=0.8.0" ],
             "override": {
                 "ksp_version_min": "1.3.0",
                 "ksp_version_max": "1.10.1",


### PR DESCRIPTION
Hi @dbent,

We wanted to make netkan's compatibility overrides work more like how it handles AVC so we could mix overrides with data from SpaceDock, see KSP-CKAN/CKAN#3265. Unfortunately, that broke this mod's metanetkan; it now has a minimum version of 1.0.2 instead of 1.3.0, because **all** of the overrides match the latest version, and if you apply all of those compatibility changes AVC-style, you end up with compatibility with basically all versions:

- https://github.com/KSP-CKAN/CKAN-meta/commit/9878758f5ce528578ffaff1baf227a01d50af791

Fortunately, the spec has an easy way to fix this! Now the overrides have both a minimum and maximum version, so only one override will match each version.

Sorry for the inconvenience!